### PR TITLE
avoid trimming msal library and fix loop bug

### DIFF
--- a/src/Client.Infrastructure/Notifications/NotificationClient.cs
+++ b/src/Client.Infrastructure/Notifications/NotificationClient.cs
@@ -80,6 +80,7 @@ public class NotificationClient : IAsyncDisposable
                 // Sending them back to /login would throw them in an endless loop.
                 // In the case of regular jwt auth, this shouldn't happen. If it does, there must be something else wrong...
                 _navigation.NavigateTo("/notfound");
+                return;
             }
             catch
             {

--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -22,5 +22,11 @@
     <ItemGroup>
         <ServiceWorker Include="wwwroot\service-worker.js" PublishedContent="wwwroot\service-worker.published.js" />
     </ItemGroup>
-
+    
+    <ItemGroup>
+        <!-- Avoid trimming of the Msal library.
+             There's something too much trimmed from Msal in the publish step. Then, after logging in,
+             the user gets redirected to authentication/login-failed with no error message. -->
+        <TrimmerRootAssembly Include="Microsoft.Authentication.WebAssembly.Msal" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
there was indeed still a loop within the signalr connection when the user isn't authenticated. I would have thought that the NavigateTo breaks down the current view (and calls disposeasync) but apparently it doesn't. Still have to get more familiar with the whole blazor model