### PR TITLE
Add validate method on AddEditModal

### DIFF
--- a/src/Client/Components/EntityTable/EntityTable.razor.cs
+++ b/src/Client/Components/EntityTable/EntityTable.razor.cs
@@ -189,8 +189,13 @@ public partial class EntityTable<TEntity, TId>
         }
 
         var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true, DisableBackdropClick = true };
-        Context.AddEditModalRef = _dialogService.Show<AddEditModal<TEntity, TId>>(isCreate ? L["Create"] : L["Edit"], parameters, options);
-        var result = await Context.AddEditModalRef.Result;
+
+        var dialog = _dialogService.Show<AddEditModal<TEntity, TId>>(isCreate ? L["Create"] : L["Edit"], parameters, options);
+
+        Context.SetAddEditModalRef(dialog);
+
+        var result = await dialog.Result;
+
         if (!result.Cancelled)
         {
             await ResetAsync();

--- a/src/Client/Components/EntityTable/EntityTableContext.cs
+++ b/src/Client/Components/EntityTable/EntityTableContext.cs
@@ -88,8 +88,6 @@ public abstract class EntityTableContext<TEntity, TId>
     /// </summary>
     public Func<bool>? HasExtraActionsFunc { get; set; }
 
-    public IDialogReference? AddEditModalRef { get; set; }
-
     public EntityTableContext(
         List<EntityField<TEntity>> fields,
         string searchPermission,
@@ -120,6 +118,11 @@ public abstract class EntityTableContext<TEntity, TId>
         HasExtraActionsFunc = hasExtraActionsFunc;
     }
 
-    public void AddEditModalForceRender() =>
-        (AddEditModalRef?.Dialog as AddEditModal<TEntity, TId>)?.ForceRender();
+    private IDialogReference? _addEditModalRef;
+
+    internal void SetAddEditModalRef(IDialogReference dialog) =>
+        _addEditModalRef = dialog;
+
+    public AddEditModal<TEntity, TId>? AddEditModal =>
+        _addEditModalRef?.Dialog as AddEditModal<TEntity, TId>;
 }

--- a/src/Client/Pages/Identity/Users.razor.cs
+++ b/src/Client/Pages/Identity/Users.razor.cs
@@ -69,6 +69,13 @@ public partial class Users
         // Add fields which are not on UserDetailsDto
         request.Password = Password;
         request.ConfirmPassword = ConfirmPassword;
+
+        // This is temporary... we should probably use another type parameter (or 2) on the AddEditModal for the request type.
+        if (Context.AddEditModal?.Validate(request) is Result result && !result.Succeeded)
+        {
+            return result;
+        }
+
         return await IdentityClient.RegisterAsync(request);
     }
 
@@ -101,6 +108,6 @@ public partial class Users
             _passwordInput = InputType.Text;
         }
 
-        Context.AddEditModalForceRender();
+        Context.AddEditModal?.ForceRender();
     }
 }


### PR DESCRIPTION
This is a bit of a hack... but for now it works:
![image](https://user-images.githubusercontent.com/775707/147559988-8f114014-c2ee-4967-8965-3ce50ec39499.png)

We should in stead probably better add another type parameter or 2 to the addEditModal... Or maybe rather replace the TEntity one with TRequest, and dynamically create the dialog with another request type according to when it's editing or creating...

I will have to think a bit more on it... but in the mean time you can make it work with this "Validate" method on the dialog.