### PR TITLE
Remove ability to edit and delete default roles

### DIFF
--- a/src/Client.Infrastructure/ApiClient/FSHApi.cs
+++ b/src/Client.Infrastructure/ApiClient/FSHApi.cs
@@ -6182,17 +6182,20 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.5.0 (NJsonSchema v10.6.6.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class RoleDto
     {
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Id { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Name { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Description { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("tenant", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Tenant { get; set; } = default!;
+
+        [Newtonsoft.Json.JsonProperty("isDefault", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsDefault { get; set; } = default!;
 
     }
 

--- a/src/Client/Components/EntityTable/EntityClientTableContext.cs
+++ b/src/Client/Components/EntityTable/EntityClientTableContext.cs
@@ -37,7 +37,9 @@ public class EntityClientTableContext<TEntity, TId, TRequest>
         string? entityName = null,
         string? entityNamePlural = null,
         Func<Task>? editFormInitializedFunc = null,
-        Func<bool>? hasExtraActionsFunc = null)
+        Func<bool>? hasExtraActionsFunc = null,
+        Func<TEntity, bool>? canUpdateEntityFunc = null,
+        Func<TEntity, bool>? canDeleteEntityFunc = null)
         : base(
             fields,
             searchPermission,
@@ -53,7 +55,9 @@ public class EntityClientTableContext<TEntity, TId, TRequest>
             entityName,
             entityNamePlural,
             editFormInitializedFunc,
-            hasExtraActionsFunc)
+            hasExtraActionsFunc,
+            canUpdateEntityFunc,
+            canDeleteEntityFunc)
     {
         LoadDataFunc = loadDataFunc;
         SearchFunc = searchFunc;

--- a/src/Client/Components/EntityTable/EntityServerTableContext.cs
+++ b/src/Client/Components/EntityTable/EntityServerTableContext.cs
@@ -31,7 +31,9 @@ public class EntityServerTableContext<TEntity, TId, TRequest>
         string? updatePermission = null,
         string? deletePermission = null,
         Func<Task>? editFormInitializedFunc = null,
-        Func<bool>? hasExtraActionsFunc = null)
+        Func<bool>? hasExtraActionsFunc = null,
+        Func<TEntity, bool>? canUpdateEntityFunc = null,
+        Func<TEntity, bool>? canDeleteEntityFunc = null)
         : base(
             fields,
             searchPermission,
@@ -47,6 +49,8 @@ public class EntityServerTableContext<TEntity, TId, TRequest>
             entityName,
             entityNamePlural,
             editFormInitializedFunc,
-            hasExtraActionsFunc) =>
+            hasExtraActionsFunc,
+            canUpdateEntityFunc,
+            canDeleteEntityFunc) =>
         SearchFunc = searchFunc;
 }

--- a/src/Client/Components/EntityTable/EntityTable.razor
+++ b/src/Client/Components/EntityTable/EntityTable.razor
@@ -108,11 +108,11 @@
                         <MudMenu Label="@L["Actions"]" Variant="Variant.Filled" DisableElevation="true"
                             EndIcon="@Icons.Filled.KeyboardArrowDown" IconColor="Color.Secondary" Direction="Direction.Left"
                             OffsetX="true">
-                            @if (_canUpdate)
+                            @if (CanUpdateEntity(context))
                             {
                                 <MudMenuItem @onclick="@(() => InvokeModal(context))">@L["Edit"]</MudMenuItem>
                             }
-                            @if (_canDelete)
+                            @if (CanDeleteEntity(context))
                             {
                                 <MudMenuItem @onclick="@(() => Delete(context))">@L["Delete"]</MudMenuItem>
                             }

--- a/src/Client/Components/EntityTable/EntityTable.razor.cs
+++ b/src/Client/Components/EntityTable/EntityTable.razor.cs
@@ -76,6 +76,8 @@ public partial class EntityTable<TEntity, TId, TRequest>
             (await AuthService.AuthorizeAsync(state.User, permission)).Succeeded);
 
     private bool HasActions => _canUpdate || _canDelete || Context.HasExtraActionsFunc is null || Context.HasExtraActionsFunc();
+    private bool CanUpdateEntity(TEntity entity) => _canUpdate && (Context.CanUpdateEntityFunc is null || Context.CanUpdateEntityFunc(entity));
+    private bool CanDeleteEntity(TEntity entity) => _canDelete && (Context.CanDeleteEntityFunc is null || Context.CanDeleteEntityFunc(entity));
 
     // Client side paging/filtering
     private bool LocalSearch(TEntity entity)

--- a/src/Client/Components/EntityTable/EntityTableContext.cs
+++ b/src/Client/Components/EntityTable/EntityTableContext.cs
@@ -103,6 +103,16 @@ public abstract class EntityTableContext<TEntity, TId, TRequest>
     /// </summary>
     public Func<bool>? HasExtraActionsFunc { get; set; }
 
+    /// <summary>
+    /// Use this if you want to disable the update functionality for specific entities in the table.
+    /// </summary>
+    public Func<TEntity, bool>? CanUpdateEntityFunc { get; set; }
+
+    /// <summary>
+    /// Use this if you want to disable the delete functionality for specific entities in the table.
+    /// </summary>
+    public Func<TEntity, bool>? CanDeleteEntityFunc { get; set; }
+
     public EntityTableContext(
         List<EntityField<TEntity>> fields,
         string searchPermission,
@@ -118,7 +128,9 @@ public abstract class EntityTableContext<TEntity, TId, TRequest>
         string? entityName,
         string? entityNamePlural,
         Func<Task>? editFormInitializedFunc,
-        Func<bool>? hasExtraActionsFunc)
+        Func<bool>? hasExtraActionsFunc,
+        Func<TEntity, bool>? canUpdateEntityFunc,
+        Func<TEntity, bool>? canDeleteEntityFunc)
     {
         Fields = fields;
         SearchPermission = searchPermission;
@@ -135,6 +147,8 @@ public abstract class EntityTableContext<TEntity, TId, TRequest>
         EntityNamePlural = entityNamePlural;
         EditFormInitializedFunc = editFormInitializedFunc;
         HasExtraActionsFunc = hasExtraActionsFunc;
+        CanUpdateEntityFunc = canUpdateEntityFunc;
+        CanDeleteEntityFunc = canDeleteEntityFunc;
     }
 
     private IDialogReference? _addEditModalRef;

--- a/src/Client/Pages/Identity/Roles.razor.cs
+++ b/src/Client/Pages/Identity/Roles.razor.cs
@@ -34,7 +34,7 @@ public partial class Roles
             {
                 new(role => role.Id, L["Id"]),
                 new(role => role.Name, L["Name"]),
-                new(role => role.Description, L["Description"]),
+                new(role => role.Description, L["Description"])
             },
             idFunc: role => role.Id,
             loadDataFunc: async () => (await RolesClient.GetListAsync()).Adapt<ListResult<RoleDto>>(),
@@ -48,7 +48,9 @@ public partial class Roles
             createPermission: FSHPermissions.Roles.Register,
             updatePermission: FSHPermissions.Roles.Update,
             deletePermission: FSHPermissions.Roles.Remove,
-            hasExtraActionsFunc: () => _canViewRoleClaims);
+            hasExtraActionsFunc: () => _canViewRoleClaims,
+            canUpdateEntityFunc: e => !e.IsDefault,
+            canDeleteEntityFunc: e => !e.IsDefault);
     }
 
     private bool Search(string? searchString, RoleDto role) =>


### PR DESCRIPTION
This one needs https://github.com/fullstackhero/dotnet-webapi-boilerplate/pull/320

When I was playing around, testing the validation on the roles view, it struck me that you could open up the editdialog for admin and basic role, but would always get an error when trying to save... same thing when trying to delete such a role. It seems better to immediately remove these options then from the menu?

I added functionality to EntityTable: you can now supply CanUpdateEntityFunc and/or CanDeleteEntityFunc with which you can show/hide the menu items for specific entities.