### PR TITLE
Clean up profile and better re-login support for AzureAD

### DIFF
--- a/src/Client.Infrastructure/Authentication/AzureAd/AzureAdAuthenticationService.cs
+++ b/src/Client.Infrastructure/Authentication/AzureAd/AzureAdAuthenticationService.cs
@@ -14,6 +14,9 @@ internal class AzureAdAuthenticationService : IAuthenticationService
 
     public AuthProvider ProviderType => AuthProvider.AzureAd;
 
+    public void NavigateToExternalLogin(string returnUrl) =>
+        _navigation.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(returnUrl)}");
+
     public Task<Result> LoginAsync(string tenantKey, TokenRequest request) =>
         throw new NotImplementedException();
 
@@ -21,5 +24,11 @@ internal class AzureAdAuthenticationService : IAuthenticationService
     {
         await _signOut.SetSignOutState();
         _navigation.NavigateTo("authentication/logout");
+    }
+
+    public Task ReLoginAsync(string returnUrl)
+    {
+        NavigateToExternalLogin(returnUrl);
+        return Task.CompletedTask;
     }
 }

--- a/src/Client.Infrastructure/Authentication/AzureAd/AzureAdClaimsPrincipalFactory.cs
+++ b/src/Client.Infrastructure/Authentication/AzureAd/AzureAdClaimsPrincipalFactory.cs
@@ -31,14 +31,24 @@ internal class AzureAdClaimsPrincipalFactory : AccountClaimsPrincipalFactory<Rem
             {
                 var userIdentity = (ClaimsIdentity)principal.Identity;
 
-                if (!userIdentity.HasClaim(c => c.Type == ClaimTypes.Email) && userDetails.Email is not null)
+                if (!string.IsNullOrWhiteSpace(userDetails.Email) && !userIdentity.HasClaim(c => c.Type == ClaimTypes.Email))
                 {
                     userIdentity.AddClaim(new Claim(ClaimTypes.Email, userDetails.Email));
                 }
 
-                if (!userIdentity.HasClaim(c => c.Type == ClaimTypes.MobilePhone) && userDetails.PhoneNumber is not null)
+                if (!string.IsNullOrWhiteSpace(userDetails.PhoneNumber) && !userIdentity.HasClaim(c => c.Type == ClaimTypes.MobilePhone))
                 {
                     userIdentity.AddClaim(new Claim(ClaimTypes.MobilePhone, userDetails.PhoneNumber));
+                }
+
+                if (!string.IsNullOrWhiteSpace(userDetails.FirstName) && !userIdentity.HasClaim(c => c.Type == ClaimTypes.Name))
+                {
+                    userIdentity.AddClaim(new Claim(ClaimTypes.Name, userDetails.FirstName));
+                }
+
+                if (!string.IsNullOrWhiteSpace(userDetails.LastName) && !userIdentity.HasClaim(c => c.Type == ClaimTypes.Surname))
+                {
+                    userIdentity.AddClaim(new Claim(ClaimTypes.Surname, userDetails.LastName));
                 }
 
                 if (!userIdentity.HasClaim(c => c.Type == FSHClaims.Fullname))
@@ -51,7 +61,7 @@ internal class AzureAdClaimsPrincipalFactory : AccountClaimsPrincipalFactory<Rem
                     userIdentity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userDetails.Id.ToString()));
                 }
 
-                if (!userIdentity.HasClaim(c => c.Type == FSHClaims.ImageUrl) && userDetails.ImageUrl is not null)
+                if (!string.IsNullOrWhiteSpace(userDetails.ImageUrl) && !userIdentity.HasClaim(c => c.Type == FSHClaims.ImageUrl) && userDetails.ImageUrl is not null)
                 {
                     userIdentity.AddClaim(new Claim(FSHClaims.ImageUrl, userDetails.ImageUrl));
                 }

--- a/src/Client.Infrastructure/Authentication/IAuthenticationService.cs
+++ b/src/Client.Infrastructure/Authentication/IAuthenticationService.cs
@@ -6,7 +6,11 @@ public interface IAuthenticationService
 {
     AuthProvider ProviderType { get; }
 
+    void NavigateToExternalLogin(string returnUrl);
+
     Task<Result> LoginAsync(string tenantKey, TokenRequest request);
 
     Task LogoutAsync();
+
+    Task ReLoginAsync(string returnUrl);
 }

--- a/src/Client.Infrastructure/Authentication/Jwt/JwtAuthenticationService.cs
+++ b/src/Client.Infrastructure/Authentication/Jwt/JwtAuthenticationService.cs
@@ -44,6 +44,9 @@ public class JwtAuthenticationService : AuthenticationStateProvider, IAuthentica
         return new AuthenticationState(new ClaimsPrincipal(claimsIdentity));
     }
 
+    public void NavigateToExternalLogin(string returnUrl) =>
+        throw new NotImplementedException();
+
     public async Task<Result> LoginAsync(string tenantKey, TokenRequest request)
     {
         var result = await _tokensClient.GetTokenAsync(tenantKey, request);
@@ -87,6 +90,12 @@ public class JwtAuthenticationService : AuthenticationStateProvider, IAuthentica
         NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
 
         _navigation.NavigateTo("/login");
+    }
+
+    public async Task ReLoginAsync(string returnUrl)
+    {
+        await LogoutAsync();
+        _navigation.NavigateTo(returnUrl);
     }
 
     public async ValueTask<AccessTokenResult> RequestAccessToken()

--- a/src/Client/Pages/Authentication/Login.razor.cs
+++ b/src/Client/Pages/Authentication/Login.razor.cs
@@ -28,7 +28,7 @@ public partial class Login
     {
         if (AuthService.ProviderType == AuthProvider.AzureAd)
         {
-            _navigationManager.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(_navigationManager.Uri)}");
+            AuthService.NavigateToExternalLogin(_navigationManager.Uri);
             return;
         }
 

--- a/src/Client/Pages/Identity/Profile.razor
+++ b/src/Client/Pages/Identity/Profile.razor
@@ -5,9 +5,9 @@
         <MudCard Elevation="25">
             <MudCardContent>
                 <div class="d-flex justify-center mb-4">
-                    @if (!string.IsNullOrEmpty(@ImageDataUrl))
+                    @if (!string.IsNullOrEmpty(@_imageDataUrl))
                     {
-                        <MudAvatar Image="@ImageDataUrl" Style="height:250px; width:250px;"> </MudAvatar>
+                        <MudAvatar Image="@_imageDataUrl" Style="height:250px; width:250px;"> </MudAvatar>
                     }
                     else
                     {
@@ -36,6 +36,8 @@
                 </MudCardHeader>
                 <MudCardContent>
                     <MudGrid>
+                        <DataAnnotationsValidator />
+                        <CustomValidation @ref="_customValidation"/>
                         <MudItem xs="12" md="6">
                             <MudTextField @bind-Value="@_profileModel.FirstName" For="@(() => _profileModel.FirstName)"
                                 Label="@_localizer["First Name"]" Variant="Variant.Outlined" />


### PR DESCRIPTION
Also support for returnUrl, so you get back on the profile page after re-logging in.

There's more things that need attention here:

* The old pictures don't seem to get deleted when a new one is uploaded?
* What's with that '{server_url}/' thats gets prepended on the imageUrl? Why not simply send what's in the database and let the client prepend the configured base url without having to know about any "magic strings"?
* Doesn't that IBrowserFile filestream need to be disposed?