### PR TITLE
Fix brand autocomplete

### DIFF
--- a/src/Client.Infrastructure/ApiClient/FSHApi.cs
+++ b/src/Client.Infrastructure/ApiClient/FSHApi.cs
@@ -1044,38 +1044,81 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<PaginationResponseOfBrandDto> SearchAsync(SearchBrandsRequest request, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Get brand details.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request);
+        System.Threading.Tasks.Task<BrandDto> GetAsync(System.Guid id);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get brand details.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<BrandDto> GetAsync(System.Guid id, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Update a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Guid> UpdateAsync(System.Guid id, UpdateBrandRequest request);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Guid> UpdateAsync(System.Guid id, UpdateBrandRequest request, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Delete a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Guid> DeleteAsync(System.Guid id);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<System.Guid> DeleteAsync(System.Guid id, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Create a new brand.
+        /// </summary>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Create a new brand.
+        /// </summary>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request, System.Threading.CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Generate a number of random brands.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<string> GenerateRandomAsync(GenerateRandomBrandRequest request);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Generate a number of random brands.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<string> GenerateRandomAsync(GenerateRandomBrandRequest request, System.Threading.CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Delete the brands generated with the generate-random call.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<string> DeleteRandomAsync();
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete the brands generated with the generate-random call.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<string> DeleteRandomAsync(System.Threading.CancellationToken cancellationToken);
 
@@ -1206,21 +1249,28 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             }
         }
 
+        /// <summary>
+        /// Get brand details.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request)
+        public virtual System.Threading.Tasks.Task<BrandDto> GetAsync(System.Guid id)
         {
-            return CreateAsync(request, System.Threading.CancellationToken.None);
+            return GetAsync(id, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get brand details.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<BrandDto> GetAsync(System.Guid id, System.Threading.CancellationToken cancellationToken)
         {
-            if (request == null)
-                throw new System.ArgumentNullException("request");
+            if (id == null)
+                throw new System.ArgumentNullException("id");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("api/v1/brands");
+            urlBuilder_.Append("api/v1/brands/{id}");
+            urlBuilder_.Replace("{id}", System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1228,10 +1278,7 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             {
                 using (var request_ = new System.Net.Http.HttpRequestMessage())
                 {
-                    var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value));
-                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
-                    request_.Content = content_;
-                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 
                     PrepareRequest(client_, request_, urlBuilder_);
@@ -1257,7 +1304,7 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
                         var status_ = (int)response_.StatusCode;
                         if (status_ == 200)
                         {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Guid>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            var objectResponse_ = await ReadObjectResponseAsync<BrandDto>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
@@ -1298,6 +1345,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             }
         }
 
+        /// <summary>
+        /// Update a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<System.Guid> UpdateAsync(System.Guid id, UpdateBrandRequest request)
         {
@@ -1305,6 +1355,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Update a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<System.Guid> UpdateAsync(System.Guid id, UpdateBrandRequest request, System.Threading.CancellationToken cancellationToken)
         {
@@ -1394,6 +1447,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             }
         }
 
+        /// <summary>
+        /// Delete a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<System.Guid> DeleteAsync(System.Guid id)
         {
@@ -1401,6 +1457,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete a brand.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<System.Guid> DeleteAsync(System.Guid id, System.Threading.CancellationToken cancellationToken)
         {
@@ -1484,6 +1543,107 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             }
         }
 
+        /// <summary>
+        /// Create a new brand.
+        /// </summary>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request)
+        {
+            return CreateAsync(request, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Create a new brand.
+        /// </summary>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<System.Guid> CreateAsync(CreateBrandRequest request, System.Threading.CancellationToken cancellationToken)
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("api/v1/brands");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var content_ = new System.Net.Http.StringContent(Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value));
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Guid>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<HttpValidationProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<HttpValidationProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ErrorResult>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ErrorResult>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Generate a number of random brands.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<string> GenerateRandomAsync(GenerateRandomBrandRequest request)
         {
@@ -1491,6 +1651,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Generate a number of random brands.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<string> GenerateRandomAsync(GenerateRandomBrandRequest request, System.Threading.CancellationToken cancellationToken)
         {
@@ -1576,6 +1739,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
             }
         }
 
+        /// <summary>
+        /// Delete the brands generated with the generate-random call.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual System.Threading.Tasks.Task<string> DeleteRandomAsync()
         {
@@ -1583,6 +1749,9 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Delete the brands generated with the generate-random call.
+        /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<string> DeleteRandomAsync(System.Threading.CancellationToken cancellationToken)
         {
@@ -6199,8 +6368,8 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid Id { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Name { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Description { get; set; } = default!;
@@ -6324,8 +6493,8 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid Id { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Name { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Description { get; set; } = default!;
@@ -6339,8 +6508,8 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         [Newtonsoft.Json.JsonProperty("brandId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid BrandId { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("brandName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? BrandName { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("brandName", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BrandName { get; set; } = default!;
 
     }
 
@@ -6364,8 +6533,8 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid Id { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string? Name { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; } = default!;
 
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? Description { get; set; } = default!;
@@ -6376,8 +6545,8 @@ namespace FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient
         [Newtonsoft.Json.JsonProperty("imagePath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string? ImagePath { get; set; } = default!;
 
-        [Newtonsoft.Json.JsonProperty("brand", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public BrandDto? Brand { get; set; } = default!;
+        [Newtonsoft.Json.JsonProperty("brand", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public BrandDto Brand { get; set; } = default!;
 
     }
 

--- a/src/Client/Pages/Catalog/Products.razor
+++ b/src/Client/Pages/Catalog/Products.razor
@@ -25,8 +25,8 @@
         <MudItem xs="12" md="6">
             <MudAutocomplete Label="@L["Brand"]" For="@(() => context.BrandId)"
                 @bind-Value="context.BrandId" ResetValueOnEmptyText="true"
-                SearchFunc="@SearchBrands" Variant="Variant.Filled"
-                ToStringFunc="@(i => _brands.FirstOrDefault(b => b.Id == i)?.Name ?? string.Empty)"
+                SearchFunc="SearchBrands" Variant="Variant.Filled"
+                ToStringFunc="GetBrandString"
                 Dense="true" Margin="Margin.Dense" />
         </MudItem>
         <MudItem xs="12" md="6">

--- a/src/Client/Pages/Catalog/Products.razor
+++ b/src/Client/Pages/Catalog/Products.razor
@@ -26,7 +26,7 @@
             <MudAutocomplete Label="@L["Brand"]" For="@(() => context.BrandId)"
                 @bind-Value="context.BrandId" ResetValueOnEmptyText="true"
                 SearchFunc="SearchBrands" Variant="Variant.Filled"
-                ToStringFunc="GetBrandString"
+                ToStringFunc="GetBrandName"
                 Dense="true" Margin="Margin.Dense" />
         </MudItem>
         <MudItem xs="12" md="6">

--- a/src/Client/Pages/Catalog/Products.razor.cs
+++ b/src/Client/Pages/Catalog/Products.razor.cs
@@ -68,7 +68,7 @@ public partial class Products
         {
             PageSize = 10,
             OrderBy = new[] { "id" },
-            AdvancedSearch = new Search { Fields = new[] { "name" }, Keyword = value }
+            AdvancedSearch = new() { Fields = new[] { "name" }, Keyword = value }
         };
 
         if (await ApiHelper.ExecuteCallGuardedAsync(
@@ -81,6 +81,6 @@ public partial class Products
         return _brands.Select(x => x.Id);
     }
 
-    private string GetBrandString(Guid id) =>
+    private string GetBrandName(Guid id) =>
         _brands.FirstOrDefault(b => b.Id == id)?.Name ?? string.Empty;
 }

--- a/src/Client/Pages/Catalog/Products.razor.cs
+++ b/src/Client/Pages/Catalog/Products.razor.cs
@@ -67,7 +67,6 @@ public partial class Products
         var filter = new SearchBrandsRequest
         {
             PageSize = 10,
-            OrderBy = new[] { "id" },
             AdvancedSearch = new() { Fields = new[] { "name" }, Keyword = value }
         };
 

--- a/src/Client/Pages/Catalog/Products.razor.cs
+++ b/src/Client/Pages/Catalog/Products.razor.cs
@@ -68,7 +68,7 @@ public partial class Products
         {
             PageSize = 10,
             OrderBy = new[] { "id" },
-            Keyword = value
+            AdvancedSearch = new Search { Fields = new[] { "name" }, Keyword = value }
         };
 
         if (await ApiHelper.ExecuteCallGuardedAsync(

--- a/src/Client/Pages/Catalog/Products.razor.cs
+++ b/src/Client/Pages/Catalog/Products.razor.cs
@@ -38,7 +38,6 @@ public partial class Products
             createFunc: async prod => await ProductsClient.CreateAsync(prod.Adapt<CreateProductRequest>()),
             updateFunc: async (id, prod) => await ProductsClient.UpdateAsync(id, prod),
             deleteFunc: async id => await ProductsClient.DeleteAsync(id),
-            editFormInitializedFunc: () => LoadBrandsAsync(),
             entityName: L["Product"],
             entityNamePlural: L["Products"],
             searchPermission: FSHPermissions.Products.Search,
@@ -65,24 +64,12 @@ public partial class Products
 
     private async Task<IEnumerable<Guid>> SearchBrands(string value)
     {
-        if (string.IsNullOrEmpty(value))
-            return _brands.Select(x => x.Id);
-
-        await LoadBrandsAsync(value);
-
-        return _brands
-            .Where(x => x.Name?.Contains(value, StringComparison.InvariantCultureIgnoreCase) ?? false)
-            .Select(x => x.Id);
-    }
-
-    private async Task LoadBrandsAsync(string? searchKeyword = default)
-    {
-        string[] orderBy = { "id" };
-        var filter = new SearchBrandsRequest { PageNumber = 0, PageSize = 10, OrderBy = orderBy };
-        if (!string.IsNullOrEmpty(searchKeyword))
+        var filter = new SearchBrandsRequest
         {
-            filter.Keyword = searchKeyword;
-        }
+            PageSize = 10,
+            OrderBy = new[] { "id" },
+            Keyword = value
+        };
 
         if (await ApiHelper.ExecuteCallGuardedAsync(
                 () => BrandsClient.SearchAsync(filter), Snackbar)
@@ -90,5 +77,10 @@ public partial class Products
         {
             _brands = response.Data.ToList();
         }
+
+        return _brands.Select(x => x.Id);
     }
+
+    private string GetBrandString(Guid id) =>
+        _brands.FirstOrDefault(b => b.Id == id)?.Name ?? string.Empty;
 }


### PR DESCRIPTION
I think we were doing the autocomplete thing not really right...

The SearchBrands method now always loads the brands and then always returns _brands.Select(b => b.Id).
No need anymore to load the brands in the OnInitialized method.

And it also uses the advanced search now to only search in the name field, so no need to filter again after the call returns.
