### PR TITLE
Fixed mud-dialog-content overflow

### DIFF
--- a/src/Client/wwwroot/css/fsh.css
+++ b/src/Client/wwwroot/css/fsh.css
@@ -48,7 +48,6 @@
 
 .mud-dialog-content {
     max-height: 75vh !important;
-    overflow: auto !important;
 }
 
 .mud-grid-spacing-xs-3 {


### PR DESCRIPTION
In the create dialog there's an overflow: auto causing the scrollbar to show.
Removing this removes the scrollbar.

![image](https://user-images.githubusercontent.com/8567057/157651493-c749c383-76cf-49a1-9fdb-c13ea62a4e2f.png)

![image](https://user-images.githubusercontent.com/8567057/157651652-7b8c228c-05bb-42ab-8c12-156e066b788d.png)
