### PR TITLE
AddEditModal: refactor

### DIFF
--- a/src/Client/Components/EntityTable/AddEditModal.razor
+++ b/src/Client/Components/EntityTable/AddEditModal.razor
@@ -10,13 +10,12 @@
                 @if (IsCreate)
                 {
                     <MudIcon Icon="@Icons.Material.Filled.Add" Class="mr-3 mb-n1" />
-                    @($"{L["Create"]} "); @L[EntityName];
                 }
                 else
                 {
                     <MudIcon Icon="@Icons.Material.Filled.Update" Class="mr-3 mb-n1" />
-                    @($"{L["Edit"]} "); @L[EntityName] 
                 }
+                @Title
             </MudText>
         </TitleContent>
 
@@ -24,28 +23,25 @@
             <DataAnnotationsValidator />
             <CustomValidation @ref="_customValidation" />
             <MudGrid>
-                @if (!IsCreate)
-                {
-                    <MudItem xs="12" md="6">
-                        <MudTextField Value="Id" ReadOnly DisableUnderLine Label="@L[$"{EntityName} Id"]" />
-                    </MudItem>
-                }
-                @EditFormContent(RequestModel)
+
+                @ChildContent(RequestModel)
 
             </MudGrid>
         </DialogContent>
 
         <DialogActions>
-            <MudButton DisableElevation Variant="Variant.Filled" OnClick="Cancel" StartIcon="@Icons.Filled.Cancel">@L["Cancel"]</MudButton>
+            <MudButton DisableElevation Variant="Variant.Filled" StartIcon="@Icons.Filled.Cancel" OnClick="MudDialog.Cancel">
+                @L["Cancel"]
+            </MudButton>
             @if (IsCreate)
             {
-                <MudButton DisableElevation Variant="Variant.Filled" ButtonType="ButtonType.Submit" Color="Color.Success" StartIcon="@Icons.Filled.Save" >
+                <MudButton DisableElevation Variant="Variant.Filled" StartIcon="@Icons.Filled.Save" ButtonType="ButtonType.Submit" Color="Color.Success">
                     @L["Save"]
                 </MudButton>
             }
             else
             {
-                <MudButton DisableElevation Variant="Variant.Filled" ButtonType="ButtonType.Submit" Color="Color.Secondary" StartIcon="@Icons.Filled.Update">
+                <MudButton DisableElevation Variant="Variant.Filled" StartIcon="@Icons.Filled.Update" ButtonType="ButtonType.Submit" Color="Color.Secondary">
                     @L["Update"]
                 </MudButton>
             }

--- a/src/Client/Components/EntityTable/AddEditModal.razor.cs
+++ b/src/Client/Components/EntityTable/AddEditModal.razor.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using FSH.BlazorWebAssembly.Client.Components.Common;
 using FSH.BlazorWebAssembly.Client.Shared;
 using Microsoft.AspNetCore.Components;
@@ -10,7 +9,7 @@ public partial class AddEditModal<TRequest> : IAddEditModal<TRequest>
 {
     [Parameter]
     [EditorRequired]
-    public RenderFragment<TRequest> EditFormContent { get; set; } = default!;
+    public RenderFragment<TRequest> ChildContent { get; set; } = default!;
     [Parameter]
     [EditorRequired]
     public TRequest RequestModel { get; set; } = default!;
@@ -21,52 +20,18 @@ public partial class AddEditModal<TRequest> : IAddEditModal<TRequest>
     public Func<Task>? OnInitializedFunc { get; set; }
     [Parameter]
     [EditorRequired]
-    public string EntityName { get; set; } = default!;
+    public string Title { get; set; } = default!;
     [Parameter]
-    public object? Id { get; set; }
+    public bool IsCreate { get; set; }
+    [Parameter]
+    public string? SuccessMessage { get; set; }
 
     [CascadingParameter]
     private MudDialogInstance MudDialog { get; set; } = default!;
 
     private CustomValidation? _customValidation;
 
-    public bool IsCreate => Id is null;
-
     public void ForceRender() => StateHasChanged();
-
-    // This should not be necessary anymore, except maybe in the case when the
-    // UpdateEntityRequest has different validation rules than the CreateEntityRequest.
-    // If that would happen a lot we can still change the design so this method doesn't need to be called manually.
-    public bool Validate(object request)
-    {
-        var results = new List<ValidationResult>();
-        if (!Validator.TryValidateObject(request, new ValidationContext(request), results, true))
-        {
-            // Convert results to errors
-            var errors = new Dictionary<string, ICollection<string>>();
-            foreach (var result in results
-                .Where(r => !string.IsNullOrWhiteSpace(r.ErrorMessage)))
-            {
-                foreach (string field in result.MemberNames)
-                {
-                    if (errors.ContainsKey(field))
-                    {
-                        errors[field].Add(result.ErrorMessage!);
-                    }
-                    else
-                    {
-                        errors.Add(field, new List<string>() { result.ErrorMessage! });
-                    }
-                }
-            }
-
-            _customValidation?.DisplayErrors(errors);
-
-            return false;
-        }
-
-        return true;
-    }
 
     protected override Task OnInitializedAsync() =>
         OnInitializedFunc is not null
@@ -76,15 +41,9 @@ public partial class AddEditModal<TRequest> : IAddEditModal<TRequest>
     private async Task SaveAsync()
     {
         if (await ApiHelper.ExecuteCallGuardedAsync(
-            () => SaveFunc(RequestModel),
-            Snackbar,
-            _customValidation,
-            $"{EntityName} {(IsCreate ? L["Created"] : L["Updated"])}."))
+            () => SaveFunc(RequestModel), Snackbar, _customValidation, SuccessMessage))
         {
             MudDialog.Close();
         }
     }
-
-    private void Cancel() =>
-        MudDialog.Cancel();
 }

--- a/src/Client/Components/EntityTable/IAddEditModal.cs
+++ b/src/Client/Components/EntityTable/IAddEditModal.cs
@@ -5,5 +5,4 @@ public interface IAddEditModal<TRequest>
     TRequest RequestModel { get; }
     bool IsCreate { get; }
     void ForceRender();
-    bool Validate(object request);
 }

--- a/src/Client/Pages/Catalog/Brands.razor
+++ b/src/Client/Pages/Catalog/Brands.razor
@@ -9,6 +9,12 @@
 <EntityTable TEntity="BrandDto" TId="Guid" TRequest="UpdateBrandRequest" Context="@Context">
 
     <EditFormContent>
+        @if (!Context.AddEditModal.IsCreate)
+        {
+            <MudItem xs="12" md="6">
+                <MudTextField Value="context.Id" ReadOnly DisableUnderLine Label="@L[$"Brand Id"]" />
+            </MudItem>
+        }
         <MudItem xs="12" md="6">
             <MudTextField T="string" For="@(() => context.Name)" @bind-Value="context.Name" Label="@L["Name"]" />
         </MudItem>

--- a/src/Client/Pages/Catalog/Products.razor
+++ b/src/Client/Pages/Catalog/Products.razor
@@ -14,6 +14,12 @@
     </AdvancedSearchContent>
 
     <EditFormContent>
+        @if (!Context.AddEditModal.IsCreate)
+        {
+            <MudItem xs="12" md="6">
+                <MudTextField Value="context.Id" ReadOnly DisableUnderLine Label="@L[$"Product Id"]" />
+            </MudItem>
+        }
         <MudItem xs="12" md="6">
             <MudTextField Label="@L["Name"]" For="@(() => context.Name)" @bind-Value="context.Name" />
         </MudItem>

--- a/src/Client/Pages/Identity/Roles/Roles.razor
+++ b/src/Client/Pages/Identity/Roles/Roles.razor
@@ -15,6 +15,12 @@
     </ExtraActions>
 
     <EditFormContent>
+        @if (!Context.AddEditModal.IsCreate)
+        {
+            <MudItem xs="12" md="6">
+                <MudTextField Value="context.Id" ReadOnly DisableUnderLine Label="@L[$"Role Id"]" />
+            </MudItem>
+        }
         <MudItem xs="12" md="6">
             <MudTextField For="@(() => context.Name)" @bind-Value="context.Name" Label="@L["Role Name"]" />
         </MudItem>

--- a/src/Client/Pages/Identity/Users/Users.razor.cs
+++ b/src/Client/Pages/Identity/Users/Users.razor.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Claims;
-using FSH.BlazorWebAssembly.Client.Components.EntityTable;
+﻿using FSH.BlazorWebAssembly.Client.Components.EntityTable;
 using FSH.BlazorWebAssembly.Client.Infrastructure.ApiClient;
 using FSH.BlazorWebAssembly.Client.Infrastructure.Auth;
 using FSH.WebApi.Shared.Authorization;

--- a/src/Client/Shared/DialogServiceExtensions.cs
+++ b/src/Client/Shared/DialogServiceExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FSH.BlazorWebAssembly.Client.Shared;
+
+public static class DialogServiceExtensions
+{
+    public static Task<DialogResult> ShowModalAsync<TDialog>(this IDialogService dialogService, DialogParameters parameters)
+        where TDialog : ComponentBase =>
+        dialogService.ShowModal<TDialog>(parameters).Result;
+
+    public static IDialogReference ShowModal<TDialog>(this IDialogService dialogService, DialogParameters parameters)
+        where TDialog : ComponentBase
+    {
+        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Medium, FullWidth = true, DisableBackdropClick = true };
+
+        return dialogService.Show<TDialog>(string.Empty, parameters, options);
+    }
+}


### PR DESCRIPTION
and make it easier to use outside of EntityTable

You can now for instance have an `UpdateCustomerDialog` component like this:

```razor
@inject ICustomersClient CustomersClient

<AddEditModal RequestModel="Customer"
    SaveFunc="@(customer => CustomersClient.UpdateAsync(customer.Id, customer))"
    Title="@(L["Edit Customer {0}", Customer.Id])">

    <CustomerFields Customer="Customer"></CustomerFields>

</AddEditModal>

@code {
    [Parameter]
    [EditorRequired]
    public UpdateCustomerRequest Customer { get; set; } = default!;
}
```

And then use it like this:
```c#
    private async Task EditCustomer()
    {
        var result = await DialogService.ShowModalAsync<UpdateCustomerDialog>(new()
        {
            { nameof(UpdateCustomerDialog.Customer), _customer!.Adapt<UpdateCustomerRequest>() }
        });

        if (!result.Cancelled)
        {
            await LoadDataAsync();
        }
    }
```

using the new `DialogServiceExtensions` (could be used to define separate dialog "options" under different methods there, which makes it a bit easier to use and keeps all those kind of options central in stead of scattered and duplicated all over the place).