### PR TITLE
global using issue fixed

### DIFF
--- a/src/Client.Infrastructure/GlobalUsings.cs
+++ b/src/Client.Infrastructure/GlobalUsings.cs
@@ -1,4 +1,7 @@
-﻿global using System.Net.Http.Headers;
+﻿global using System;
+global using System.Threading.Tasks;
+global using System.Net.Http.Headers;
+global using System.Collections.Generic;
 global using System.Security.Claims;
 global using System.Text.Json;
 global using Blazored.LocalStorage;

--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -7,7 +7,6 @@
         <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
         <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
     </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Mapster" Version="7.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.3" />
@@ -16,7 +15,9 @@
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="MudBlazor" Version="6.0.9" />
     </ItemGroup>
-
+    <ItemGroup>
+        <Compile Include="..\Client.Infrastructure\GlobalUsings.cs"/> <!-- Assuming your file sits one level up -->
+    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Client.Infrastructure\Client.Infrastructure.csproj" />
         <ProjectReference Include="..\Shared\Shared.csproj" />


### PR DESCRIPTION
The globalUsings can not be auto-shared in cross-projects. so I added GlobalUsings.cs to compile for "Client" project automatically. Picks the file from "Client.Infrastructure" and adds it to "Client" at compile time.