### PR TITLE
Powershell scripts should be cross-platform

### DIFF
--- a/scripts/nswag-regen.ps1
+++ b/scripts/nswag-regen.ps1
@@ -1,7 +1,9 @@
+# This script is cross-platform, supporting all OSes that PowerShell Core/7 runs on.
+
 $currentDirectory = Get-Location
 $rootDirectory = git rev-parse --show-toplevel
-$hostDirectory = $rootDirectory + '/src/Host'
-$infrastructurePrj = $rootDirectory + '/src/Client.Infrastructure/Client.Infrastructure.csproj'
+$hostDirectory = Join-Path -Path $rootDirectory -ChildPath 'src/Host'
+$infrastructurePrj = Join-Path -Path $rootDirectory -ChildPath 'src/Client.Infrastructure/Client.Infrastructure.csproj'
 
 Write-Host "Make sure you have run the FSH.WebApi project. `n"
 Write-Host "Press any key to continue... `n"

--- a/scripts/pull-shared-from-webapi.ps1
+++ b/scripts/pull-shared-from-webapi.ps1
@@ -1,19 +1,40 @@
-$source = "..\..\dotnet-webapi-boilerplate\src\Core\Shared"
-$destination = "..\src\Shared"
+# This script is cross-platform, supporting all OSes that PowerShell Core/7 runs on.
+
+$rootDirectory = git rev-parse --show-toplevel
+$sourcePath = Join-Path -Path $rootDirectory -ChildPath '..\dotnet-webapi-boilerplate\src\Core\Shared'
+$destinationPath = Join-Path -Path $rootDirectory -ChildPath 'src\Shared'
+
 $excludes = @('bin', 'obj')
 
 Write-Host "Pull changes from the Fullstackhero WebApi Shared Project"
 write-Host "---------------------------------------------------------"
 Write-Host
-Write-Host "WARNING! This will delete everything in the shared project ($destination)"
-Write-Host "and then copy over the whole project from the webapi repository ($source)"
-Write-Host
-Write-Host "Please make sure the fsh webapi repostory is available on your machine next to this one!"
+
+If ($null -eq $sourcePath) {
+    Write-Error "Error! The expected path of WebApi Shared Project does not exist: $sourcePath"
+    Exit 1
+}
+
+if ($null -eq (Resolve-Path $destinationPath)) {
+    # Ensure the destination exists
+    try
+    {
+        New-Item -Path $destinationPath -ItemType Directory -ErrorAction Stop | Out-Null
+    }
+    catch
+    {
+        Write-Error "Error! Unable to create output path \"$destinationPath\""
+        Exit 1
+    }
+}
+
+Write-Host "WARNING! This will delete everything in the shared project ($($destinationPath | Resolve-Path))"
+Write-Host "and then copy over the whole project from the webapi repository ($($sourcePath | Resolve-Path))"
 Write-Host
 Read-Host -Prompt "Press ENTER to continue"
 
-Remove-Item -Path "$destination\*"  -Recurse
-Copy-Item -Path (Get-Item -Path "$source\*" -Exclude $excludes).FullName -Destination $destination -Recurse -Force
+Remove-Item -Path "$destinationPath"  -Recurse -Force
+Copy-Item -Path (Get-Item -Path "$sourcePath" -Exclude $excludes).FullName -Destination "$destinationPath" -Recurse -Force
 
 Write-Host "Changes have been pulled."
 Write-Host


### PR DESCRIPTION
1. Scripts now cross-platform, wherever PowerShell Core/7 is installed
2. `pull-shared-from-webapi` now asked `git` for the root path. like its sibling script, allowing it be be executed outside the `scripts` folder (but must still be inside the webapp's structure)
3. Some helpful sanity checking and handling in `pull-shared-from-webapi`